### PR TITLE
Fix salary prefill, preserve all posting locations, store posting URL

### DIFF
--- a/agents/job_analyzer.py
+++ b/agents/job_analyzer.py
@@ -112,6 +112,7 @@ AI_SYSTEM_CONTEXT: str = """You are an expert job posting analyst with 15+ years
 - Distinguish REQUIRED vs PREFERRED qualifications carefully
 - When uncertain, use null rather than guessing
 - Capture ALL skills mentioned, even in passing
+- Capture ALL listed locations — many postings offer several offices; never drop any
 - Identify HIDDEN requirements (e.g., "fast-paced" = adaptability needed)"""
 
 JOB_ANALYSIS_PROMPT: str = """Analyze this job posting and extract ALL structured information.
@@ -126,9 +127,10 @@ Extract information into this EXACT JSON structure. Output ONLY valid JSON, no e
 {{
     "company_name": "<company/organization name or null>",
     "job_title": "<exact job title as posted>",
-    "job_city": "<city or null if remote/not specified>",
-    "job_state": "<state/province or null>",
+    "job_city": "<primary city (first listed) or null if remote/not specified>",
+    "job_state": "<state/province of the primary city or null>",
     "job_country": "<country or null>",
+    "additional_locations": ["<'City, State' or 'City, Country' for EVERY other location the posting lists beyond the primary — postings often list several offices (e.g. 'San Francisco, CA | New York City, NY'); empty array if only one location>"],
     "employment_type": "<full-time | part-time | contract | temporary | internship | null>",
     "work_arrangement": "<onsite | remote | hybrid | null>",
     "salary_range": {{
@@ -477,6 +479,9 @@ class JobAnalyzerAgent:
                 job_city=parsed_data.get("job_city"),
                 job_state=parsed_data.get("job_state"),
                 job_country=parsed_data.get("job_country"),
+                additional_locations=_normalize_string_list(
+                    parsed_data.get("additional_locations")
+                ),
                 employment_type=parsed_data.get("employment_type"),
                 work_arrangement=parsed_data.get("work_arrangement"),
                 salary_range=parsed_data.get("salary_range") or {},

--- a/agents/profile_matching.py
+++ b/agents/profile_matching.py
@@ -621,6 +621,7 @@ class ProfileMatchingAgent:
 - Job Title: {job.get('job_title', 'Not provided')}
 - Company: {job.get('company_name', 'Not provided')}
 - Location: {job.get('job_city', 'N/A')}, {job.get('job_state', 'N/A')}, {job.get('job_country', 'N/A')}
+- Additional Locations Offered: {'; '.join(job.get('additional_locations') or []) or 'None listed'} (when judging location fit, consider ALL offered locations and use the one closest to the candidate)
 - Work Arrangement: {job.get('work_arrangement', 'Not specified')}
 - Employment Type: {job.get('employment_type', 'Not specified')}
 - Company Size: {job.get('company_size', 'Not specified')}

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -574,6 +574,8 @@ async def start_workflow(
     job_text: Optional[str] = Form(None),
     detected_title_form: Optional[str] = Form(None, alias="detected_title"),
     detected_company_form: Optional[str] = Form(None, alias="detected_company"),
+    source_form: Optional[str] = Form(None, alias="source"),
+    source_url_form: Optional[str] = Form(None, alias="source_url"),
     current_user: Dict[str, Any] = Depends(get_current_user_with_complete_profile),
     db: AsyncSession = Depends(get_database),
 ) -> WorkflowStartResponse:
@@ -702,8 +704,8 @@ async def start_workflow(
 
         # Get extension-specific metadata (JSON body takes priority; Form fields are the
         # extension path where request is None)
-        source = request.source if request else None
-        source_url = request.source_url if request else None
+        source = (request.source if request else None) or source_form
+        source_url = (request.source_url if request else None) or source_url_form
         detected_title = (request.detected_title if request else None) or detected_title_form
         detected_company = (request.detected_company if request else None) or detected_company_form
 

--- a/tests/test_agents/test_job_analyzer.py
+++ b/tests/test_agents/test_job_analyzer.py
@@ -74,6 +74,7 @@ def mock_gemini_client():
             "job_city": "San Francisco",
             "job_state": "California",
             "job_country": "USA",
+            "additional_locations": ["New York City, NY", "Seattle, WA"],
             "employment_type": "full-time",
             "work_arrangement": "hybrid",
             "salary_range": {"min": 150000, "max": 200000, "currency": "USD", "period": "yearly"},
@@ -184,6 +185,39 @@ class TestManualInputProcessing:
         
         assert "job_analysis" in result
         assert result["job_analysis"]["job_title"] == "Senior Software Engineer"
+
+    @pytest.mark.asyncio
+    async def test_additional_locations_extracted(
+        self, mock_gemini_client, workflow_state_manual
+    ):
+        """All listed locations beyond the primary are preserved."""
+        agent = JobAnalyzerAgent(gemini_client=mock_gemini_client)
+
+        with patch('agents.job_analyzer.get_cached_job_analysis', return_value=None), \
+             patch('agents.job_analyzer.cache_job_analysis', return_value=None):
+            result = await agent.process(workflow_state_manual)
+
+        assert result["job_analysis"]["additional_locations"] == [
+            "New York City, NY",
+            "Seattle, WA",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_additional_locations_default_empty(
+        self, mock_gemini_client, workflow_state_manual
+    ):
+        """Missing additional_locations in the LLM response maps to an empty list."""
+        payload = mock_gemini_client.generate.return_value["response"].replace(
+            '"additional_locations": ["New York City, NY", "Seattle, WA"],', ''
+        )
+        mock_gemini_client.generate.return_value = {"response": payload, "filtered": False}
+        agent = JobAnalyzerAgent(gemini_client=mock_gemini_client)
+
+        with patch('agents.job_analyzer.get_cached_job_analysis', return_value=None), \
+             patch('agents.job_analyzer.cache_job_analysis', return_value=None):
+            result = await agent.process(workflow_state_manual)
+
+        assert result["job_analysis"]["additional_locations"] == []
 
     @pytest.mark.asyncio
     async def test_process_manual_input_too_short(self, mock_gemini_client):

--- a/ui/dashboard/application.html
+++ b/ui/dashboard/application.html
@@ -3561,6 +3561,10 @@
                                     <i class="fas fa-calendar-alt"></i>
                                     Posted <span id="postedDateText"></span>
                                 </span>
+                                <span class="job-meta-item is-hidden" id="jobUrlMeta">
+                                    <i class="fas fa-external-link-alt"></i>
+                                    <a id="jobUrlLink" href="#" target="_blank" rel="noopener noreferrer">View posting</a>
+                                </span>
                             </div>
                             <div class="job-badges">
                                 <span class="job-badge badge-salary is-hidden" id="salaryBadge">

--- a/ui/static/js/application-detail.js
+++ b/ui/static/js/application-detail.js
@@ -387,7 +387,9 @@
         if (cdEl) cdEl.textContent = new Date().toLocaleDateString();
 
         // Location
-        const location = [job.job_city, job.job_state, job.job_country].filter(Boolean).join(', ');
+        const _extraLocations = Array.isArray(job.additional_locations) ? job.additional_locations.filter(Boolean) : [];
+        const _primaryLocation = [job.job_city, job.job_state, job.job_country].filter(Boolean).join(', ');
+        const location = [_primaryLocation, ..._extraLocations].filter(Boolean).join(' | ');
         if (location) {
             const jlEl = document.getElementById('jobLocation');
             const lmEl = document.getElementById('locationMeta');
@@ -967,7 +969,9 @@
             // Bare number → append %; already has % or is descriptive → keep as-is
             return /^\d+$/.test(str) ? `${str}%` : str;
         })();
-        const jobLocation = [job.job_city, job.job_state, job.job_country].filter(Boolean).join(', ');
+        const _jdExtraLocations = Array.isArray(job.additional_locations) ? job.additional_locations.filter(Boolean) : [];
+        const _jdPrimaryLocation = [job.job_city, job.job_state, job.job_country].filter(Boolean).join(', ');
+        const jobLocation = [_jdPrimaryLocation, ..._jdExtraLocations].filter(Boolean).join(' | ');
 
         // Salary display (reuse already-computed header value or rebuild)
         /** @type {Record<string,string>} */

--- a/ui/static/js/application-detail.js
+++ b/ui/static/js/application-detail.js
@@ -357,6 +357,15 @@
         // Store job URL and application ID
         currentApplicationId = data['application_id'] || null;
 
+        // Original posting link
+        const jobUrl = typeof data['job_url'] === 'string' ? data['job_url'] : '';
+        const jobUrlMeta = document.getElementById('jobUrlMeta');
+        const jobUrlLink = /** @type {HTMLAnchorElement|null} */ (document.getElementById('jobUrlLink'));
+        if (jobUrlMeta && jobUrlLink && /^https?:\/\//.test(jobUrl)) {
+            jobUrlLink.href = jobUrl;
+            jobUrlMeta.classList.remove('is-hidden');
+        }
+
         // Render header
         renderHeader(job, match);
 

--- a/ui/static/js/profile-setup.js
+++ b/ui/static/js/profile-setup.js
@@ -406,10 +406,12 @@
 
         // Job preferences
         if (profileData.desired_salary_range) {
-            document.getElementById("min-salary").value =
-                profileData.desired_salary_range.min;
-            document.getElementById("max-salary").value =
-                profileData.desired_salary_range.max;
+            const minSalaryEl = /** @type {HTMLInputElement|null} */ (document.getElementById("min-salary"));
+            const maxSalaryEl = /** @type {HTMLInputElement|null} */ (document.getElementById("max-salary"));
+            const parsedMin = parseSalaryDigits(profileData.desired_salary_range.min);
+            const parsedMax = parseSalaryDigits(profileData.desired_salary_range.max);
+            if (minSalaryEl) minSalaryEl.value = parsedMin > 0 ? String(parsedMin) : "";
+            if (maxSalaryEl) maxSalaryEl.value = parsedMax > 0 ? String(parsedMax) : "";
         }
 
         // Company sizes

--- a/workflows/state_schema.py
+++ b/workflows/state_schema.py
@@ -201,6 +201,7 @@ class JobAnalysisResult:
     job_city: Optional[str] = None
     job_state: Optional[str] = None
     job_country: Optional[str] = None
+    additional_locations: Optional[List[str]] = field(default_factory=list)
     employment_type: Optional[str] = None
     work_arrangement: Optional[str] = None
     salary_range: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
Three fixes found while running ApplyPilot end-to-end on a real 55-posting batch:

## 1. `bdbea09` — fix(profile): guard salary prefill against undefined parse values
CV parse can return `undefined` for salary fields; the prefill rendered the literal string "undefined" into the salary inputs. Added explicit guards.

## 2. `b1915b3` — feat(analyzer): preserve all posting locations, not just the first
The job analyzer kept only the first location from multi-location postings. For remote-friendly roles listing e.g. "SF, NYC, Remote", this tanked match scores badly (observed 48% → 94% on rerun after the fix). Adds `additional_locations` to `JobAnalysisResult`, feeds all locations to the profile matcher, and displays them on the application detail page. Includes 2 new unit tests.

## 3. `05c6b1b` — feat(workflow): posting URL via form path + View-posting link
`POST /workflow/start` (form path) never stored the posting URL, so applications had no way back to the original posting. Accepts `source`/`source_url` as Form fields and renders a "View posting" link on the detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)