### PR TITLE
chore: update links after GitHub rename to rolemule

### DIFF
--- a/.claude/rules/landing-page.mdc
+++ b/.claude/rules/landing-page.mdc
@@ -13,7 +13,7 @@ The landing page lives at `ui/index.html` and uses `ui/static/css/landing.css` +
 |---------|-----------|-------|
 | Hero | `.hero-section` | Tagline **One mule for every role.** + 4-step explainer; paste / PDF·TXT·DOCX / extension |
 | ↓ section arrow | `.section-arrow.section-arrow--hero` | Hero → tech-bar |
-| Tech Bar | `.section-tech-bar` | Built-with tags (incl. Gemini/OpenAI/Anthropic/Ollama) + GitHub link to `eliornl/applypilot` |
+| Tech Bar | `.section-tech-bar` | Built-with tags (incl. Gemini/OpenAI/Anthropic/Ollama) + GitHub link to `eliornl/rolemule` |
 | ↓ section arrow | `.section-arrow` | Between each subsequent section pair |
 | Problem | `#problem` `.section-problem` | ~150-application stat + time comparison cards |
 | Features | `#features` `.section-features` | Label **Workflow Agents**; **5** pipeline agents (`.features-grid`) |

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability (private)
-    url: https://github.com/eliornl/applypilot/security/advisories/new
+    url: https://github.com/eliornl/rolemule/security/advisories/new
     about: Do not open a public issue — report security problems privately via GitHub Security Advisories.
   - name: Contributing guide
-    url: https://github.com/eliornl/applypilot/blob/main/CONTRIBUTING.md
+    url: https://github.com/eliornl/rolemule/blob/main/CONTRIBUTING.md
     about: Development setup, code style, tests, and pull request process.
   - name: Questions
-    url: https://github.com/eliornl/applypilot/blob/main/CONTRIBUTING.md#questions
+    url: https://github.com/eliornl/rolemule/blob/main/CONTRIBUTING.md#questions
     about: General questions are welcome — include your OS, runtime, and what you've already tried.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Profile setup adds **work authorization** (radio), **visa sponsorship** (checkbo
 
 #### Rebrand — ApplyPilot → RoleMule
 
-Product display name is now **RoleMule** (tagline: **One mule for every role.**). CLI entry point `rolemule`, client package `rolemule_client` / `RoleMuleClient`, PAT prefix `rm_pat_`, localStorage `rolemule_*`, and WS bus `rolemule:ws`. Favicon / navbar / extension icons use the mule mark (`docs/rolemule-icon.png`). **Postgres DB user/name stays `applypilot`** so existing `DATABASE_URL` values keep working. GitHub repo rename (`eliornl/applypilot` → `eliornl/rolemule`) is deferred until approved.
+Product display name is now **RoleMule** (tagline: **One mule for every role.**). CLI entry point `rolemule`, client package `rolemule_client` / `RoleMuleClient`, PAT prefix `rm_pat_`, localStorage `rolemule_*`, and WS bus `rolemule:ws`. Favicon / navbar / extension icons use the mule mark (`docs/rolemule-icon.png`). **Postgres DB user/name stays `applypilot`** so existing `DATABASE_URL` values keep working. GitHub repo renamed: `eliornl/applypilot` → `eliornl/rolemule`.
 
 #### Landing page — feature catch-up
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,15 +110,15 @@ See [SECURITY.md](SECURITY.md) for supported versions, scope, private reporting 
 
 **macOS / Linux:**
 ```bash
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 make start
 ```
 
 **Windows** — install [`just`](https://just.systems) (`winget install Casey.Just`), then:
 ```powershell
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 just start
 ```
 
@@ -141,8 +141,8 @@ make docker-reset / just docker-reset  # stop + wipe all data
 One command installs PostgreSQL and Redis via Homebrew, creates the database, and starts the app:
 
 ```bash
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 make start-local
 ```
 
@@ -159,8 +159,8 @@ make dev            # restart just the app (services already running)
 Use this if you already have PostgreSQL and Redis running. **Windows users:** use `just` instead of `make` (`winget install Casey.Just`).
 
 ```bash
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 make setup       # or: just setup   (Windows) — includes rolemule CLI in venv
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ Three ways to run it — pick the one that suits you:
 **macOS / Linux** — `make` is pre-installed:
 
 ```bash
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 make start
 ```
 
 **Windows** — install [just](https://just.systems) (`winget install Casey.Just`) instead of `make`. It works natively in PowerShell and cmd — no WSL2 needed, and **no Git for Windows / `cygpath` required** for `just start` (only Docker Desktop + `just`).
 
 ```powershell
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 just start
 ```
 
@@ -126,8 +126,8 @@ make docker-reset / just docker-reset  # stop and wipe all data
 **What you need:** macOS. No Docker, no manual installs — `make start-local` installs everything it needs (Homebrew, Python 3, Node.js, PostgreSQL, Redis) automatically on the first run. If Homebrew isn't installed yet, you'll be prompted for your **sudo password** once in the terminal — this is normal and required to install Homebrew.
 
 ```bash
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 make start-local
 ```
 
@@ -158,16 +158,16 @@ Use this if you already have PostgreSQL and Redis running (any platform, any set
 macOS / Linux:
 
 ```bash
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 make setup          # creates venv, installs deps + CLI, builds frontend, generates .env
 ```
 
 Windows — install [just](https://just.systems) (`winget install Casey.Just`) first:
 
 ```powershell
-git clone https://github.com/eliornl/applypilot.git
-cd applypilot
+git clone https://github.com/eliornl/rolemule.git
+cd rolemule
 just setup
 ```
 
@@ -463,7 +463,7 @@ Frontend: server-rendered HTML + **TypeScript** (Vite-bundled per page), no Reac
 ## Project Structure
 
 ```
-applypilot/                 # clone folder (GitHub repo: eliornl/applypilot)
+rolemule/                   # GitHub: eliornl/rolemule (local folder may still be applypilot/)
 ├── main.py                 # FastAPI app entry point
 ├── cli/                    # RoleMule CLI (Typer; command: rolemule)
 ├── rolemule_client/        # Sync HTTP client for the CLI

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ If you are running a fork or a pinned older commit, please upgrade to the latest
 
 Report security issues privately using one of these channels:
 
-1. **[GitHub Security Advisories](https://github.com/eliornl/applypilot/security/advisories/new)** (preferred) — use **Report a vulnerability** on the [Security tab](https://github.com/eliornl/applypilot/security).
+1. **[GitHub Security Advisories](https://github.com/eliornl/rolemule/security/advisories/new)** (preferred) — use **Report a vulnerability** on the [Security tab](https://github.com/eliornl/rolemule/security).
 2. **Direct contact** — message the repository maintainer privately via their [GitHub profile](https://github.com/eliornl).
 
 Public issues for security problems may be deleted or converted to private advisories without notice.
@@ -86,9 +86,9 @@ RoleMule runs continuous security checks on `main`:
 
 | Check | Where | Notes |
 |-------|-------|-------|
-| **CodeQL** | [Code scanning](https://github.com/eliornl/applypilot/security/code-scanning) | Python + TypeScript/JavaScript (`ui/src/`, `extension/`); config in [`.github/codeql/codeql-config.yml`](.github/codeql/codeql-config.yml) |
-| **Secret scanning** | [Secret scanning](https://github.com/eliornl/applypilot/security/secret-scanning) | Flags leaked API keys; use non-`AIza` test keys in tests |
-| **Dependabot** | [Dependabot alerts](https://github.com/eliornl/applypilot/security/dependabot) | CVE alerts + automated security update PRs |
+| **CodeQL** | [Code scanning](https://github.com/eliornl/rolemule/security/code-scanning) | Python + TypeScript/JavaScript (`ui/src/`, `extension/`); config in [`.github/codeql/codeql-config.yml`](.github/codeql/codeql-config.yml) |
+| **Secret scanning** | [Secret scanning](https://github.com/eliornl/rolemule/security/secret-scanning) | Flags leaked API keys; use non-`AIza` test keys in tests |
+| **Dependabot** | [Dependabot alerts](https://github.com/eliornl/rolemule/security/dependabot) | CVE alerts + automated security update PRs |
 | **Ruff lint** | GitHub Actions [`ci.yml`](.github/workflows/ci.yml) | Style + unused-import checks on every push |
 | **Security grep** | GitHub Actions [`ci.yml`](.github/workflows/ci.yml) | Convention checks via `scripts/ci-security-grep.sh` |
 | **E2E (live)** | GitHub Actions [`ci.yml`](.github/workflows/ci.yml) | Full Playwright suite when UI/backend/e2e paths change |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -589,4 +589,4 @@ A: PDF, DOCX, and TXT files up to 10 MB.
 A: On self-hosted instances without SMTP, the password reset page shows the reset link directly on screen after you submit your email — no email is sent. Copy the link, open it, and set your new password. If you are the operator and want to enable email delivery, configure the `SMTP_*` variables in your `.env` file.
 
 **Q: Something looks broken — how do I report it?**  
-A: Open an issue at `https://github.com/eliornl/applypilot/issues` with the steps to reproduce, what you expected, and what actually happened.
+A: Open an issue at `https://github.com/eliornl/rolemule/issues` with the steps to reproduce, what you expected, and what actually happened.

--- a/ui/errors/500.html
+++ b/ui/errors/500.html
@@ -128,7 +128,7 @@
                 </div>
                 <div class="status-item">
                     <i class="fab fa-github"></i>
-                    <span>If the problem persists, <a href="https://github.com/eliornl/applypilot/issues" target="_blank" rel="noopener noreferrer" class="support-link">open a GitHub issue</a></span>
+                    <span>If the problem persists, <a href="https://github.com/eliornl/rolemule/issues" target="_blank" rel="noopener noreferrer" class="support-link">open a GitHub issue</a></span>
                 </div>
             </div>
 

--- a/ui/help.html
+++ b/ui/help.html
@@ -924,7 +924,7 @@
                 <h2>Still need help?</h2>
                 <p>Can't find what you're looking for? Open an issue on GitHub.</p>
                 <div class="d-flex gap-3 justify-content-center flex-wrap">
-                    <a href="https://github.com/eliornl/applypilot/issues" target="_blank" rel="noopener noreferrer" class="btn btn-primary-glow">
+                    <a href="https://github.com/eliornl/rolemule/issues" target="_blank" rel="noopener noreferrer" class="btn btn-primary-glow">
                         <i class="fab fa-github me-2"></i> Open a GitHub Issue
                     </a>
                 </div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -95,7 +95,7 @@
                     <span>LangGraph</span>
                     <span>Docker</span>
                 </div>
-                <a href="https://github.com/eliornl/applypilot" target="_blank" rel="noopener noreferrer" class="tech-bar-link">
+                <a href="https://github.com/eliornl/rolemule" target="_blank" rel="noopener noreferrer" class="tech-bar-link">
                     <i class="fab fa-github"></i>
                     View on GitHub
                 </a>
@@ -694,7 +694,7 @@ rolemule workflow results SESSION --section cover-letter</code></pre>
                     <a href="/terms">Terms</a>
                 </div>
                 <div class="footer-meta">
-                    <a href="https://github.com/eliornl/applypilot" target="_blank" rel="noopener noreferrer" class="footer-github">
+                    <a href="https://github.com/eliornl/rolemule" target="_blank" rel="noopener noreferrer" class="footer-github">
                         <i class="fab fa-github"></i> Open Source on GitHub
                     </a>
                     <p>© 2026 RoleMule</p>

--- a/ui/legal/privacy.html
+++ b/ui/legal/privacy.html
@@ -288,7 +288,7 @@
                 <p>The project maintainers may update this policy in the source repository. Instance operators are responsible for keeping this page current with their own deployment practices.</p>
 
                 <h2 id="contact">10. Contact</h2>
-                <p>For questions about your data on this specific instance, contact the person who set it up. For questions about the open-source software itself, open an issue on the <a href="https://github.com/eliornl/applypilot" target="_blank" rel="noopener noreferrer">GitHub repository</a>.</p>
+                <p>For questions about your data on this specific instance, contact the person who set it up. For questions about the open-source software itself, open an issue on the <a href="https://github.com/eliornl/rolemule" target="_blank" rel="noopener noreferrer">GitHub repository</a>.</p>
 
                 <div class="highlight-box">
                     <p>You can exercise most data rights yourself without contacting anyone: export your data or delete your account directly from <strong>Dashboard → Settings</strong>.</p>

--- a/ui/legal/terms.html
+++ b/ui/legal/terms.html
@@ -208,7 +208,7 @@
                 <p>By using this instance of RoleMule, you agree to these Terms of Use. If you do not agree, do not use the software. You must be at least 16 years old to create an account.</p>
 
                 <h2 id="service-description">2. About This Software</h2>
-                <p>RoleMule is free, open-source software licensed under the MIT License. The source code is publicly available on <a href="https://github.com/eliornl/applypilot" target="_blank" rel="noopener noreferrer">GitHub</a>. You are running a self-hosted instance — all your data stays in your own database on the machine where this instance is deployed.</p>
+                <p>RoleMule is free, open-source software licensed under the MIT License. The source code is publicly available on <a href="https://github.com/eliornl/rolemule" target="_blank" rel="noopener noreferrer">GitHub</a>. You are running a self-hosted instance — all your data stays in your own database on the machine where this instance is deployed.</p>
                 <p>The software provides:</p>
                 <ul>
                     <li>Job posting analysis and requirements extraction (including PDF, TXT, and DOCX uploads)</li>
@@ -296,7 +296,7 @@
                 <p>This software is provided free of charge. Use it at your own risk.</p>
 
                 <h2 id="contact">13. Contact</h2>
-                <p>For questions about these Terms or to report issues with the software, open an issue on the <a href="https://github.com/eliornl/applypilot" target="_blank" rel="noopener noreferrer">GitHub repository</a>.</p>
+                <p>For questions about these Terms or to report issues with the software, open an issue on the <a href="https://github.com/eliornl/rolemule" target="_blank" rel="noopener noreferrer">GitHub repository</a>.</p>
 
                 <div class="highlight-box">
                     <p>By creating an account, you confirm that you are at least 16 years old and agree to these Terms of Use.</p>

--- a/ui/maintenance.html
+++ b/ui/maintenance.html
@@ -135,7 +135,7 @@
             </p>
             
             <div class="social-links">
-                <a href="https://github.com/eliornl/applypilot" target="_blank" rel="noopener noreferrer" title="GitHub">
+                <a href="https://github.com/eliornl/rolemule" target="_blank" rel="noopener noreferrer" title="GitHub">
                     <i class="fab fa-github"></i>
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- GitHub repository renamed: `eliornl/applypilot` → `eliornl/rolemule`
- Update clone URLs, legal/help/landing GitHub links, issue template URLs, and CHANGELOG

## Test plan
- [ ] Open https://github.com/eliornl/rolemule
- [ ] Spot-check landing footer + tech-bar GitHub links
- [ ] Confirm README clone instructions use `eliornl/rolemule` and `cd rolemule`