### PR TITLE
chore(deps): batch safe pip and npm bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,10 @@ jobs:
             requirements-dev.txt
       - run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          # Pin to the same major floor as requirements-dev.txt — unpinned
+          # `pip install ruff` can pull 0.16+ which enables thousands of new
+          # findings before the codebase is ready for that upgrade.
+          pip install 'ruff>=0.15.22,<0.16'
       - run: ruff check .
 
   python-tests:

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,25 +8,25 @@
       "name": "rolemule-e2e",
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^26.1.1",
         "typescript": "^6.0.3"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@types/node": {
@@ -55,35 +55,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/typescript": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -44,7 +44,7 @@
     "install-browsers": "playwright install --with-deps"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.0",
     "@types/node": "^26.1.1",
     "typescript": "^6.0.3"
   }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # Development, testing, and CI-only dependencies (not required at runtime).
 # Install after production deps: pip install -r requirements.txt && pip install -r requirements-dev.txt
-ruff>=0.15.21
+ruff>=0.15.22
 pytest>=9.0
 pytest-asyncio>=1.4.0
-pytest-cov>=7.0.0
-pip-audit>=2.7.0
+pytest-cov>=7.1.0
+pip-audit>=2.10.1
 # Optional load testing: locust -f tests/load/locustfile.py --host=http://localhost:8000
 locust>=2.32.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Development, testing, and CI-only dependencies (not required at runtime).
 # Install after production deps: pip install -r requirements.txt && pip install -r requirements-dev.txt
-ruff>=0.15.22
+ruff>=0.15.22,<0.16
 pytest>=9.0
 pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,6 @@ python-docx==1.2.0
 odfpy==1.4.1
 PyMuPDF==1.26.3
 docx2txt==0.9
-python-multipart==0.0.31
-email-validator==2.2.0
+python-multipart==0.0.32
+email-validator==2.3.0
 python-dotenv==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ defusedxml==0.7.1
 distro==1.9.0
 dnspython==2.8.0
 docx2txt==0.9
-email-validator==2.2.0
+email-validator==2.3.0
 fastapi==0.135.0
 frozenlist==1.8.0
 google-auth[requests]==2.55.1
@@ -50,7 +50,7 @@ ormsgpack==1.12.2
 packaging==26.2
 passlib[bcrypt]==1.7.4
 propcache==0.5.2
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1-modules==0.4.2
 pycparser==3.0
 pydantic==2.13.4
@@ -60,7 +60,7 @@ pyjwt==2.13.0
 pymupdf==1.26.3
 python-docx==1.2.0
 python-dotenv==1.2.2
-python-multipart==0.0.31
+python-multipart==0.0.32
 pyyaml==6.0.3
 redis==6.2.0
 requests==2.34.2

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rolemule-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^7.3.0"
+        "@fortawesome/fontawesome-free": "^7.3.1"
       },
       "devDependencies": {
         "@types/node": "^26.1.1",
@@ -461,9 +461,9 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.0.tgz",
-      "integrity": "sha512-Yw4Qa43P6e4Xwh0TwEUkHQNRJInWaqIBo73VJmns3j2AIlZPAvUcR4yGIxCPqPRCgyJ5KIVIalF/I1GxhZ/Kgw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+      "integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"
@@ -1185,9 +1185,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1261,7 +1261,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,6 @@
     "vitest": "^3.1.4"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^7.3.0"
+    "@fortawesome/fontawesome-free": "^7.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- Combines low-risk Dependabot bumps into one update:
  - **pip:** `email-validator` 2.3.0, `python-multipart` 0.0.32, `pyasn1` 0.6.4 (security), `ruff` ≥0.15.22, `pytest-cov` ≥7.1.0, `pip-audit` ≥2.10.1
  - **npm:** Font Awesome 7.3.1, `postcss` 8.5.25, Playwright 1.62.x
- Supersedes: #61, #54, #52, #59, #56, #55, #50, #63, #62
- Intentionally leaves majors for dedicated PRs: `google-genai` (#58), `redis` (#57), `bcrypt` (#53), FastAPI (#51), uvicorn (#60), Vite (#49), TypeScript (#26/#22), Vitest (#25)

## Test plan
- [x] `pip check`
- [ ] CI green on this PR
- [ ] Close superseded Dependabot PRs after merge